### PR TITLE
Remove WWW from build link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is about a cool first game I'm busy developing. It's not ready y
 
 This game is based of the original Wave game by RTG.
 
-Download builds at : https://www.ci.scarsz.me/job/Squared
+Download builds at : https://ci.scarsz.me/job/Squared
 
 Levels 1 and 2 are only playable levels for now. Levels will be added with each new version.
 Please report bugs, feature requests or feedback about levels or anything in the issues tab here on github.


### PR DESCRIPTION
The www subdomain is apparently not supported on the website.